### PR TITLE
Ledger Nano S Plus Compatibility

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -12,11 +12,11 @@ This document lists all the officially supported software and devices by Wasabi 
 
 # Officially Supported Hardware Wallets
 
-- ColdCard MK1
 - ColdCard MK2
 - ColdCard MK3
 - ColdCard MK4
 - Ledger Nano S
+- Ledger Nano S Plus
 - Ledger Nano X
 - Trezor Model T
 


### PR DESCRIPTION
Added Nano S Plus mention and deleted Coldcard MK1 compatibility, because the device is long time unsupported.

Only approve once support for the Nano S Plus is merged.